### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -3,9 +3,8 @@ name: C/C++ CI
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
-  push:
     branches: [ action-test ]
 
 jobs:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*'
 
-    branches: [ action-test ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -2,6 +2,10 @@ name: C/C++ CI
 
 on:
   push:
+    tags:
+      - '*'
+
+  push:
     branches: [ action-test ]
 
 jobs:
@@ -33,9 +37,11 @@ jobs:
       run: |
         rm -f packages/*
         make package FINALPACKAGE=1
-    
-    - name: Upload package
-      uses: actions/upload-artifact@v2.2.0
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: 'Package'
-        path: ${{ github.workspace }}/packages/*.deb
+        files: ${{ github.workspace }}/packages/*.deb
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,0 +1,41 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ action-test ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Check cache
+      id: verify-cache
+      run: |
+        echo "::set-output name=heads::`git ls-remote https://github.com/theos/theos | head -n 1 | cut -f 1`-`git ls-remote https://github.com/xybp888/iOS-SDKs | head -n 1 | cut -f 1`"
+
+    - name: Use cache
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/theos
+        key: ${{ runner.os }}-${{ steps.verify-cache.outputs.heads }}
+
+    - name: Prepare Theos
+      uses: Randomblock1/theos-action@v1
+
+    - name: Build package
+      run: |
+        rm -f packages/*
+        make package FINALPACKAGE=1
+    
+    - name: Upload package
+      uses: actions/upload-artifact@v2.2.0
+      with:
+        name: 'Package'
+        path: ${{ github.workspace }}/packages/*.deb


### PR DESCRIPTION
Use `git tag v1.1.1` to issue a new release, GitHub will do the rest for you.

If you wanna test github-action without actually publishing the artifact, use a new `action-test` branch